### PR TITLE
(android) stashing intentlogging changes

### DIFF
--- a/cordova-plugin-inappbrowser-popup-bridge.iml
+++ b/cordova-plugin-inappbrowser-popup-bridge.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/android" isTestSource="false" packagePrefix="org.apache.cordova.inappbrowser" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,6 +47,7 @@
         <source-file src="src/android/InAppBrowser.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppBrowserDialog.java" target-dir="src/org/apache/cordova/inappbrowser" />
         <source-file src="src/android/InAppChromeClient.java" target-dir="src/org/apache/cordova/inappbrowser" />
+        <source-file src="src/android/IntentLogger.java" target-dir="src/org/apache/cordova/inappbrowser" />
 
         <!-- drawable src/android/resources -->
         <resource-file src="src/android/res/drawable-hdpi/ic_action_next_item.png" target="res/drawable-hdpi/ic_action_next_item.png" />

--- a/src/android/IntentLogger.java
+++ b/src/android/IntentLogger.java
@@ -1,0 +1,76 @@
+package org.apache.cordova.inappbrowser;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+import java.util.Set;
+
+import static android.content.Intent.URI_INTENT_SCHEME;
+
+public class IntentLogger {
+
+    private static final String TAG = "FL1VVR";
+
+    public static void logFullContent(Intent intent) {
+
+        Log.v(TAG, "Intent.toString(): " + intent.toString());
+        Log.v(TAG, "Intent.toUri(): " + intent.toUri(URI_INTENT_SCHEME));
+
+        Log.v(TAG, "Package: " + intent.getPackage());
+
+        Log.v(TAG, "Action: " + intent.getAction());
+
+        Log.v(TAG, "Type: " + intent.getType());
+
+        printCategories(intent.getCategories());
+
+        Log.v(TAG, "Component: " + intent.getComponent());
+
+        Log.v(TAG, "Data String: " + intent.getDataString());
+
+        printExtras(intent.getExtras());
+    }
+
+    private static void printExtras(Bundle extras) {
+
+        if(extras == null){
+
+            Log.v(TAG, "Extras: null");
+
+        } else {
+
+            if(extras.isEmpty()){
+
+                Log.v(TAG, "Extras: not null, but empty");
+
+            } else {
+
+                for(String extraKey : extras.keySet()){
+                    Log.v(TAG, "Extra: " + extraKey + ": " + extras.get(extraKey));
+                }
+            }
+        }
+    }
+
+    private static void printCategories(Set<String> categories) {
+
+        if(categories == null){
+
+            Log.v(TAG, "Categories: null");
+
+        } else {
+
+            if(categories.isEmpty()){
+
+                Log.v(TAG, "Categories: not null, but empty");
+
+            } else {
+
+                for(String category : categories){
+                    Log.v(TAG, "Category: " + category);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION


### Platforms affected
Android


### Motivation and Context
Logs the raw Intent passed into the Activity


### Description
Adds some logging features, shouldn't anything else.


### Testing
Executed locally in gna_kindred.pa Android app to see intent raw data in logs.


### Checklist

- [x ] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
