### PR TITLE
AP-1066: Added null check to avoid app crash

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -438,7 +438,11 @@ public class InAppBrowser extends CordovaPlugin {
                 @SuppressLint("NewApi")
                 @Override
                 public void run() {
-                    inAppWebView.evaluateJavascript(finalScriptToInject, null);
+                    if (inAppWebView != null) {
+                        inAppWebView.evaluateJavascript(finalScriptToInject, null);
+                    } else {
+                        LOG.e(LOG_TAG, "inAppWebView is null in run() method");
+                    }
                 }
             });
         } else {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://boydinteractive.atlassian.net/browse/AP-1066

The NullPointerException occurs because inAppWebView is null when you we to call evaluateJavascript on it. This can happen if inAppWebView has not been properly initialized or has been destroyed before this method is called.

Exception java.lang.NullPointerException: Attempt to invoke virtual method 'void android.webkit.WebView.evaluateJavascript(java.lang.String, android.webkit.ValueCallback)' on a null object reference
  at org.apache.cordova.inappbrowser.InAppBrowser$5.run (InAppBrowser.java:441)

### Description
<!-- Describe your changes in detail -->
Ensure that inAppWebView is properly initialized before calling evaluateJavascript by adding a null check


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing performed to verify basic functionalities in android. 

- Open Venmo external link in IAB
- Close IAB
- Complete payment from Venmo application and return back to the IAB
- Minimize mobile app and re-open when IAB is opened


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
